### PR TITLE
Add mermaid overview for specs workflow

### DIFF
--- a/docs/specs-workflow-mermaid.md
+++ b/docs/specs-workflow-mermaid.md
@@ -4,7 +4,7 @@ The diagram below traces the current end-to-end workflow implemented by the comp
 
 ```mermaid
 flowchart TD
-    A[Spec created or selected<br>(specs.sync/specs.next)] --> B[Issue on Specs Board<br>Todo]
+    A[Spec created or selected<br/>specs.sync or specs.next] --> B[Issue on Specs Board<br/>Todo]
     B --> C[ADR/Design discussion opened<br/>and approved]
     C --> D[Branch + PR per spec<br/>(commit messages reference issue)]
     D --> E[Codex wrappers use spec-kit templates<br/>for planning and tasks]
@@ -12,7 +12,7 @@ flowchart TD
     F --> G[Security scans: Semgrep, OSV-Scanner,<br/>Gitleaks, Checkov]
     G --> H[PR checks green<br/>(Status: In Progress)]
     H --> I[Release workflow (tag + GitHub Release)<br/>changelog/wiki/discussion updated]
-    I --> J[specs close --pr #<br>Issue closed, Specs Board -> Done]
+    I --> J[specs close --pr #<br/>Issue closed, Specs Board -> Done]
 ```
 
 ## How the workflow is enabled


### PR DESCRIPTION
## Summary
- add mermaid flowchart documenting the end-to-end specs workflow
- outline how completed specs enable each stage of the workflow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939345c4ac08324aa6e401ce7117953)