### PR TITLE
Make release workflow inert on non-dispatch events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,3 +140,9 @@ EOF
     runs-on: ubuntu-latest
     steps:
       - run: echo "No version provided; skipping release."
+
+  release-ignore-other-events:
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Release workflow is ignored for event ${GITHUB_EVENT_NAME}."


### PR DESCRIPTION
## Summary
- release workflow: add ignore job for non-dispatch events to keep runs green
- ensures release workflow succeeds when triggered by push (no jobs) and only runs release on manual dispatch with version

Spec issue: #14 https://github.com/ganesh47/specs/issues/14
ADR/design review discussion: https://github.com/ganesh47/specs/discussions/16
Wiki page for spec/ADR: https://github.com/ganesh47/specs/wiki/Release-Workflow-Automation

## Testing
- not run (workflow change)
