### PR TITLE
Cut 0.2.0 release for release.workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0 - Release workflow automation
+- Added manual release workflow with tagging, release notes, ADR/wiki updates, and coverage artifact upload.
+- Hardened guardrails (issue/ADR/wiki checks, security scans, Checkov exception for required release inputs) to keep release PRs gated.
+- Policy: closing a spec now requires a minor version bump and release via the new workflow.
+
 ## 0.1.0 - Initial scaffold
 - Add specs CLI skeleton and commands
 - Add GitHub coverage action

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "specs-monorepo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "specs-monorepo",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "workspaces": [
         "packages/specs-cli",
@@ -1002,7 +1002,7 @@
     },
     "packages/specs-cli": {
       "name": "specs",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.0.0",
@@ -1024,7 +1024,7 @@
       }
     },
     "packages/specs-coverage-action": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specs-monorepo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "workspaces": [
     "packages/specs-cli",

--- a/packages/specs-cli/package.json
+++ b/packages/specs-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Spec-Driven Development Kit CLI",
   "bin": {
     "specs": "./bin/specs.js"

--- a/packages/specs-coverage-action/package.json
+++ b/packages/specs-coverage-action/package.json
@@ -1,9 +1,13 @@
 {
   "name": "specs-coverage-action",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "GitHub Action to run specs coverage",
   "main": "dist/index.js",
-  "files": ["dist", "action.yml", "README.md"],
+  "files": [
+    "dist",
+    "action.yml",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc -b",
     "lint": "echo 'lint todo'"


### PR DESCRIPTION
## Summary
- Bump specs packages to v0.2.0 and record release workflow automation in changelog.
- Enforce policy that spec closure triggers a minor version bump and release via the new workflow.

Spec issue: #14 https://github.com/ganesh47/specs/issues/14
ADR/design review discussion: https://github.com/ganesh47/specs/discussions/16
Wiki page for spec/ADR: https://github.com/ganesh47/specs/wiki/Release-Workflow-Automation

## Required checks
- [ ] spec-kit templates refreshed (`specs scan --refresh-spec-kit` or `specs templates`)
- [ ] Spec-kit availability check passed (`npm run spec-kit:check`)
- [ ] Specs coverage run
- [ ] Example conformance run (if applicable)
- [ ] Security scans (Semgrep/OSV-Scanner/Gitleaks/Checkov) green
- [ ] ADR/design review approved in discussion #16
- [ ] Issue and project status updated (Todo → In Progress → Done)
