### PR TITLE
Fix changelog heading for 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.0 - Release workflow automation
+## v0.2.0 - Release workflow automation
 - Added manual release workflow with tagging, release notes, ADR/wiki updates, and coverage artifact upload.
 - Hardened guardrails (issue/ADR/wiki checks, security scans, Checkov exception for required release inputs) to keep release PRs gated.
 - Policy: closing a spec now requires a minor version bump and release via the new workflow.


### PR DESCRIPTION
## Summary
- Adjust changelog heading to include v0.2.0 so release workflow can extract notes.

Spec issue: #14 https://github.com/ganesh47/specs/issues/14
ADR/design review discussion: https://github.com/ganesh47/specs/discussions/16
Wiki page for spec/ADR: https://github.com/ganesh47/specs/wiki/Release-Workflow-Automation

## Required checks
- [ ] spec-kit templates refreshed (`specs scan --refresh-spec-kit` or `specs templates`)
- [ ] Spec-kit availability check passed (`npm run spec-kit:check`)
- [ ] Specs coverage run
- [ ] Example conformance run (if applicable)
- [ ] Security scans (Semgrep/OSV-Scanner/Gitleaks/Checkov) green
- [ ] ADR/design review approved in discussion #16
- [ ] Issue and project status updated (Todo → In Progress → Done)
