### PR TITLE
Fix wiki publish in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,8 @@ jobs:
           tmpdir=$(mktemp -d)
           git clone "https://x-access-token:${GH_TOKEN}@github.com/ganesh47/specs.wiki.git" "$tmpdir/specs.wiki"
           cd "$tmpdir/specs.wiki"
+          git config user.name "specs-bot"
+          git config user.email "specs-bot@users.noreply.github.com"
           cat >> Release-Workflow-Automation.md <<EOF
 
           ## ${TAG}


### PR DESCRIPTION
## Summary
- Set git user.name/email when updating the wiki during release so pushes succeed.

Spec issue: #14 https://github.com/ganesh47/specs/issues/14
ADR/design review discussion: https://github.com/ganesh47/specs/discussions/16
Wiki page for spec/ADR: https://github.com/ganesh47/specs/wiki/Release-Workflow-Automation

## Required checks
- [ ] spec-kit templates refreshed (`specs scan --refresh-spec-kit` or `specs templates`)
- [ ] Spec-kit availability check passed (`npm run spec-kit:check`)
- [ ] Specs coverage run
- [ ] Example conformance run (if applicable)
- [ ] Security scans (Semgrep/OSV-Scanner/Gitleaks/Checkov) green
- [ ] ADR/design review approved in discussion #16
- [ ] Issue and project status updated (Todo → In Progress → Done)
