### PR TITLE
Handle reruns in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,11 @@ jobs:
         env:
           TAG: ${{ steps.prep.outputs.tag }}
         run: |
-          gh release create "$TAG" --latest --notes-file release-notes.md --target main
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --latest --notes-file release-notes.md
+          else
+            gh release create "$TAG" --latest --notes-file release-notes.md --target main
+          fi
 
       - name: Upload coverage artifact to release
         env:


### PR DESCRIPTION
## Summary
- Allow release workflow to edit an existing tag/release instead of failing when rerun.

Spec issue: #14 https://github.com/ganesh47/specs/issues/14
ADR/design review discussion: https://github.com/ganesh47/specs/discussions/16
Wiki page for spec/ADR: https://github.com/ganesh47/specs/wiki/Release-Workflow-Automation

## Required checks
- [ ] spec-kit templates refreshed (`specs scan --refresh-spec-kit` or `specs templates`)
- [ ] Spec-kit availability check passed (`npm run spec-kit:check`)
- [ ] Specs coverage run
- [ ] Example conformance run (if applicable)
- [ ] Security scans (Semgrep/OSV-Scanner/Gitleaks/Checkov) green
- [ ] ADR/design review approved in discussion #16
- [ ] Issue and project status updated (Todo → In Progress → Done)
