### PR TITLE
Enable issue comments in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 permissions:
   contents: write
   pull-requests: read
-  issues: read
+  issues: write
   discussions: write
 
 jobs:


### PR DESCRIPTION
## Summary
- Grant issue write permission so the release workflow can comment on the spec issue after publishing.

Spec issue: #14 https://github.com/ganesh47/specs/issues/14
ADR/design review discussion: https://github.com/ganesh47/specs/discussions/16
Wiki page for spec/ADR: https://github.com/ganesh47/specs/wiki/Release-Workflow-Automation

## Required checks
- [ ] spec-kit templates refreshed (`specs scan --refresh-spec-kit` or `specs templates`)
- [ ] Spec-kit availability check passed (`npm run spec-kit:check`)
- [ ] Specs coverage run
- [ ] Example conformance run (if applicable)
- [ ] Security scans (Semgrep/OSV-Scanner/Gitleaks/Checkov) green
- [ ] ADR/design review approved in discussion #16
- [ ] Issue and project status updated (Todo → In Progress → Done)
