### PR TITLE
Add Codex specs command and ADR/wiki automation

### DIFF
--- a/.codex/commands/specs
+++ b/.codex/commands/specs
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# codex specs: delegate to specs CLI with fallback and a simple doctor mode.
+
+SPEC_CMD="specs"
+if ! command -v specs >/dev/null 2>&1; then
+  SPEC_CMD="npx specs"
+fi
+
+if [[ "${1-}" == "--doctor" || "${1-}" == "doctor" ]]; then
+  echo "Codex specs doctor:"
+  if command -v specs >/dev/null 2>&1; then
+    echo "- specs found at $(command -v specs)"
+    specs --version || true
+  else
+    echo "- specs not installed globally; falling back to npx."
+    echo "  Install with: npm i -g specs"
+  fi
+  exit 0
+fi
+
+eval "$SPEC_CMD" "$@"

--- a/.github/workflows/spec-guard.yml
+++ b/.github/workflows/spec-guard.yml
@@ -22,29 +22,35 @@ jobs:
         run: |
           set -euo pipefail
 
-          body=$(gh pr view "$PR_NUMBER" --json body --jq .body)
-
-          issue=$(printf "%s" "$body" | grep -oE "#[0-9]+" | head -n1 | tr -d '#')
+          pr_body=$(gh pr view "$PR_NUMBER" --json body --jq .body)
+          issue=$(printf "%s" "$pr_body" | grep -oE "#[0-9]+" | head -n1 | tr -d '#')
           if [ -z "${issue:-}" ]; then
             echo "Missing spec issue reference (#123) in PR body."
             exit 1
           fi
 
-          adr_url=$(printf "%s" "$body" | grep -oE "https://github.com/.+/discussions/[0-9]+" | head -n1 || true)
-          if [ -z "${adr_url:-}" ]; then
-            echo "Missing ADR discussion URL in PR body."
-            exit 1
-          fi
-
-          wiki_url=$(printf "%s" "$body" | grep -oE "https://github.com/.+/wiki/[^ )\"]+" | head -n1 || true)
-          if [ -z "${wiki_url:-}" ]; then
-            echo "Missing wiki URL in PR body."
-            exit 1
-          fi
-
-          issue_state=$(gh issue view "$issue" --json state --jq .state)
+          issue_body=$(gh issue view "$issue" --json body,state --jq '{body:.body,state:.state}')
+          issue_state=$(printf "%s" "$issue_body" | jq -r .state)
           if [ "$issue_state" != "OPEN" ]; then
             echo "Spec issue #$issue is not open (state=$issue_state)."
+            exit 1
+          fi
+          issue_text=$(printf "%s" "$issue_body" | jq -r .body)
+
+          adr_url_pr=$(printf "%s" "$pr_body" | grep -oE "https://github.com/.+/discussions/[0-9]+" | head -n1 || true)
+          wiki_url_pr=$(printf "%s" "$pr_body" | grep -oE "https://github.com/.+/wiki/[^ )\"]+" | head -n1 || true)
+          adr_url_issue=$(printf "%s" "$issue_text" | grep -oE "https://github.com/.+/discussions/[0-9]+" | head -n1 || true)
+          wiki_url_issue=$(printf "%s" "$issue_text" | grep -oE "https://github.com/.+/wiki/[^ )\"]+" | head -n1 || true)
+
+          adr_url=${adr_url_pr:-$adr_url_issue}
+          wiki_url=${wiki_url_pr:-$wiki_url_issue}
+
+          if [ -z "${adr_url:-}" ]; then
+            echo "Missing ADR discussion URL in PR or issue body."
+            exit 1
+          fi
+          if [ -z "${wiki_url:-}" ]; then
+            echo "Missing wiki URL in PR or issue body."
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,14 @@ codex spec-next
 - GitHub CLI (`gh`) installed and authenticated for sync/approval/PR actions
 
 ## Using with Codex CLI
-Place executable scripts in `.codex/commands/` (provided in this repo) so Codex can invoke `specs` commands as native subcommands.
+Place executable scripts in `.codex/commands/` (provided in this repo) so Codex can invoke `specs` commands as native subcommands:
+- `codex specs` (new): delegates to `specs` or `npx specs` and supports `--doctor` to report install status/version.
+- `codex spec-next`, `codex spec-sync`, `codex spec-coverage`, `codex approve`: wrappers that call specs CLI/gh helpers directly.
+
+Install/upgrade/uninstall:
+- Global: `npm i -g specs` (upgrade with `npm i -g specs@latest`, uninstall with `npm rm -g specs`).
+- Local fallback: `npx specs <verb>` (used automatically by `codex specs` if global is missing).
+- Optional: set `PATH` to the repo-built binary (`packages/specs-cli/bin/specs.js`) for development.
 
 ## Repository layout
 - `packages/specs-cli`: the main CLI

--- a/packages/specs-cli/src/commands/sync.ts
+++ b/packages/specs-cli/src/commands/sync.ts
@@ -29,7 +29,11 @@ export function registerSync(program: Command) {
       const labels = config.github?.issue_labels || ['spec'];
       for (const spec of specs) {
         try {
-          const issueNumber = await gh.upsertIssue(spec, labels);
+          const adrUrl = await gh.ensureAdrDiscussion(spec);
+          const issueNumber = await gh.upsertIssue(spec, labels, { adrUrl });
+          const wiki = await gh.ensureWikiPage(spec, adrUrl, issueNumber);
+          // Update issue once wiki is created to ensure link is present.
+          await gh.upsertIssue(spec, labels, { adrUrl, wikiUrl: wiki.url });
           // eslint-disable-next-line no-console
           console.log(`Synced spec ${spec.specId} -> issue #${issueNumber || '?'} `);
           if (issueNumber) {

--- a/packages/specs-cli/src/core/ghClient.ts
+++ b/packages/specs-cli/src/core/ghClient.ts
@@ -29,11 +29,13 @@ export class GhClient {
     'Release',
     'Close',
   ];
-
   private projectCache: Record<
     string,
     { projectId: string; fieldId?: string; options?: Record<string, string> }
   > = {};
+
+  private repoInfo?: { owner: string; name: string; id?: string };
+  private authToken?: string;
 
   private async execGh(args: string): Promise<string> {
     try {
@@ -53,9 +55,13 @@ export class GhClient {
     }
   }
 
-  async upsertIssue(spec: SpecDoc, labels: string[] = []): Promise<number> {
+  async upsertIssue(
+    spec: SpecDoc,
+    labels: string[] = [],
+    links: { adrUrl?: string; wikiUrl?: string } = {}
+  ): Promise<number> {
     const title = spec.title ? `Spec: ${spec.title}` : `Spec: ${spec.specId}`;
-    const bodyFile = this.createBodyFile(this.buildIssueBody(spec));
+    const bodyFile = this.createBodyFile(this.buildIssueBody(spec, undefined, undefined, links));
 
     // Prefer to find by title (stable) and fall back to body search using spec_id.
     const foundByTitle = await this.searchIssuesByTitle(title);
@@ -68,16 +74,22 @@ export class GhClient {
       // Preserve existing completion state from current issue body.
       let completedFeatures = new Set<string>();
       let completedPhases = new Set<string>();
+      let existingLinks: { adrUrl?: string; wikiUrl?: string } = {};
       try {
         const existingBody = await this.getIssueBody(issueNumber);
         completedFeatures = this.parseCompletedFeatures(existingBody, spec);
         completedPhases = this.parseCompletedPhases(existingBody);
+        existingLinks = this.parseLinks(existingBody);
       } catch {
         completedFeatures = new Set<string>();
         completedPhases = new Set<string>();
+        existingLinks = {};
       }
       const updatedBodyFile = this.createBodyFile(
-        this.buildIssueBody(spec, completedFeatures, completedPhases)
+        this.buildIssueBody(spec, completedFeatures, completedPhases, {
+          adrUrl: links.adrUrl || existingLinks.adrUrl,
+          wikiUrl: links.wikiUrl || existingLinks.wikiUrl,
+        })
       );
       const labelArg = labels.length ? ` --add-label "${labels.join(',')}"` : '';
       await this.execGh(
@@ -90,15 +102,25 @@ export class GhClient {
     const output = await this.execGh(
       `issue create --title "${title}" --body-file "${bodyFile}"${labelArg}`
     );
-    const match = output.match(/#(\\d+)/);
+    const match = output.match(/#(\d+)/);
     return match ? Number(match[1]) : 0;
   }
 
   buildIssueBody(
     spec: SpecDoc,
     completedFeatures: Set<string> = new Set(),
-    completedPhases: Set<string> = new Set()
+    completedPhases: Set<string> = new Set(),
+    links: { adrUrl?: string; wikiUrl?: string } = {}
   ): string {
+    const linkLines: string[] = [];
+    if (links.adrUrl) {
+      linkLines.push(`- ADR: ${links.adrUrl}`);
+    }
+    if (links.wikiUrl) {
+      linkLines.push(`- Wiki: ${links.wikiUrl}`);
+    }
+    const linksBlock = linkLines.length ? `Links:\n${linkLines.join('\n')}\n\n` : '';
+
     const phaseList = this.phaseOrder
       .map((p) => `- [${completedPhases.has(p) ? 'x' : ' '}] ${p}`)
       .join('\n');
@@ -111,9 +133,8 @@ export class GhClient {
         return `- [${checked}] ${f.id}${acceptText}`;
       })
       .join('\n');
-    return `Spec ID: ${spec.specId}\nFile: ${spec.filePath}\n\nPhases:\n${phaseList}\n\nFeatures:\n${featureList}\n`;
+    return `Spec ID: ${spec.specId}\nFile: ${spec.filePath}\n\n${linksBlock}Phases:\n${phaseList}\n\nFeatures:\n${featureList}\n`;
   }
-
   async addToProject(
     projectCfg: ProjectConfig,
     issueNumber: number,
@@ -189,7 +210,14 @@ export class GhClient {
   async completeAllAndClose(spec: SpecDoc, issueNumber: number): Promise<void> {
     const allFeatures = new Set(spec.features.map((f) => f.id));
     const allPhases = new Set(this.phaseOrder);
-    const body = this.buildIssueBody(spec, allFeatures, allPhases);
+    let links: { adrUrl?: string; wikiUrl?: string } = {};
+    try {
+      const existingBody = await this.getIssueBody(issueNumber);
+      links = this.parseLinks(existingBody);
+    } catch {
+      links = {};
+    }
+    const body = this.buildIssueBody(spec, allFeatures, allPhases, links);
     await this.updateIssueBody(issueNumber, body);
     await this.closeIssue(issueNumber);
   }
@@ -346,5 +374,183 @@ export class GhClient {
       }
     }
     return completed;
+  }
+
+  private parseLinks(body: string): { adrUrl?: string; wikiUrl?: string } {
+    const adrMatch = body.match(/ADR:\s*(https:\/\/github\.com\/[^\s]+)/i);
+    const wikiMatch = body.match(/Wiki:\s*(https:\/\/github\.com\/[^\s]+)/i);
+    return {
+      adrUrl: adrMatch ? adrMatch[1] : undefined,
+      wikiUrl: wikiMatch ? wikiMatch[1] : undefined,
+    };
+  }
+
+  private async getRepoInfo(): Promise<{ owner: string; name: string; id?: string }> {
+    if (this.repoInfo) return this.repoInfo;
+    try {
+      const raw = await this.execGh(
+        `repo view --json owner,name,id --jq '{owner:.owner.login,name:.name,id:.id}'`
+      );
+      const parsed = JSON.parse(raw);
+      this.repoInfo = { owner: parsed.owner, name: parsed.name, id: parsed.id };
+    } catch (error) {
+      // Fall back to git remote parsing
+      const remote = fs
+        .readFileSync(path.join(this.cwd, '.git', 'config'), 'utf8')
+        .split('\n')
+        .find((line) => line.includes('github.com'));
+      if (remote) {
+        const match = remote.match(/github\.com[:/](.+?)\/(.+?)(\.git)?$/);
+        if (match) {
+          this.repoInfo = { owner: match[1], name: match[2] };
+        }
+      }
+    }
+    if (this.repoInfo && !this.repoInfo.id) {
+      try {
+        const raw = await this.execGh(
+          `api graphql -f query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){id}}' -f owner=${this.repoInfo.owner} -f name=${this.repoInfo.name}`
+        );
+        const parsed = JSON.parse(raw);
+        this.repoInfo.id = parsed?.data?.repository?.id;
+      } catch {
+        // ignore lookup failures
+      }
+    }
+    if (!this.repoInfo?.owner || !this.repoInfo?.name) {
+      throw new Error('Unable to determine repository owner/name for discussions/wiki.');
+    }
+    return this.repoInfo;
+  }
+
+  private slugifyName(input: string): string {
+    return input
+      .trim()
+      .replace(/[^a-zA-Z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  private async getAuthToken(): Promise<string | undefined> {
+    if (this.authToken) return this.authToken;
+    if (process.env.GH_TOKEN || process.env.GITHUB_TOKEN) {
+      this.authToken = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+      return this.authToken;
+    }
+    try {
+      const token = await this.execGh('auth token');
+      this.authToken = token;
+      return this.authToken;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async ensureAdrDiscussion(spec: SpecDoc): Promise<string> {
+    const repo = await this.getRepoInfo();
+    const preferredTitle = `ADR: ${spec.specId}`;
+    const altTitle = spec.title ? `ADR: ${spec.title}` : preferredTitle;
+
+    const queries = [
+      `repo:${repo.owner}/${repo.name} "${preferredTitle}" in:title`,
+      `repo:${repo.owner}/${repo.name} "${altTitle}" in:title`,
+      `repo:${repo.owner}/${repo.name} "${spec.specId}" in:title`,
+    ];
+
+    for (const q of queries) {
+      try {
+        const rawSearch = await this.execGh(
+          `api graphql -f query='query($q:String!){search(query:$q,type:DISCUSSION,first:10){nodes{... on Discussion{number title url}}}}' -f q="${q}"`
+        );
+        const parsed = JSON.parse(rawSearch);
+        const nodes = parsed?.data?.search?.nodes || [];
+        const candidates = nodes.filter((n: any) =>
+          String(n?.title || '').toLowerCase().includes(spec.specId.toLowerCase())
+        );
+        if (candidates.length) {
+          const chosen = candidates.sort((a: any, b: any) => Number(a.number) - Number(b.number))[0];
+          if (chosen?.url) {
+            return chosen.url as string;
+          }
+        }
+      } catch {
+        // ignore and continue
+      }
+    }
+
+    const categoriesRaw = await this.execGh(
+      `api graphql -f query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){id discussionCategories(first:20){nodes{id name}}}}' -f owner=${repo.owner} -f name=${repo.name}`
+    );
+    const categories = JSON.parse(categoriesRaw)?.data?.repository?.discussionCategories?.nodes || [];
+    const adrCategory =
+      categories.find((c: any) => String(c?.name || '').toLowerCase().includes('adr')) ||
+      categories[0];
+    if (!adrCategory?.id || !repo.id) {
+      throw new Error('Unable to find ADR discussion category or repository id.');
+    }
+
+    const body = `ADR for spec ${spec.specId}\n\nSpec file: ${spec.filePath}${
+      spec.title ? `\nTitle: ${spec.title}` : ''
+    }`;
+    const createRaw = await this.execGh(
+      `api graphql -f query='mutation($repoId:ID!,$categoryId:ID!,$title:String!,$body:String!){createDiscussion(input:{repositoryId:$repoId,categoryId:$categoryId,title:$title,body:$body}){discussion{url}}}' -f repoId=${repo.id} -f categoryId=${adrCategory.id} -f title="${preferredTitle}" -f body="${body.replace(
+        /"/g,
+        '\\"'
+      )}"`
+    );
+    const url = JSON.parse(createRaw)?.data?.createDiscussion?.discussion?.url;
+    if (!url) {
+      throw new Error('Failed to create ADR discussion.');
+    }
+    return url as string;
+  }
+
+  async ensureWikiPage(
+    spec: SpecDoc,
+    adrUrl?: string,
+    issueNumber?: number
+  ): Promise<{ url: string }> {
+    const repo = await this.getRepoInfo();
+    const slug = this.slugifyName(spec.title ? `Spec ${spec.title}` : `Spec ${spec.specId}`);
+    const pageName = `${slug || spec.specId}`;
+    const wikiUrl = `https://github.com/${repo.owner}/${repo.name}/wiki/${pageName}`;
+
+    const token = await this.getAuthToken();
+    const remote = token
+      ? `https://x-access-token:${token}@github.com/${repo.owner}/${repo.name}.wiki.git`
+      : `https://github.com/${repo.owner}/${repo.name}.wiki.git`;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'specs-wiki-'));
+    try {
+      await exec(`git clone ${remote} "${tmpDir}"`, { cwd: this.cwd });
+    } catch (error: any) {
+      throw new Error(`Unable to clone wiki repo: ${error?.stderr || error?.message || error}`);
+    }
+
+    const filePath = path.join(tmpDir, `${pageName}.md`);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const lines = [
+      `# ${spec.title || spec.specId}`,
+      '',
+      `- Spec ID: ${spec.specId}`,
+      `- Spec file: ${spec.filePath}`,
+    ];
+    if (issueNumber) {
+      lines.push(`- Issue: https://github.com/${repo.owner}/${repo.name}/issues/${issueNumber}`);
+    }
+    if (adrUrl) {
+      lines.push(`- ADR: ${adrUrl}`);
+    }
+    lines.push('', 'Generated by specs sync.');
+    fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf8');
+
+    const status = (await exec(`git status --porcelain`, { cwd: tmpDir })).stdout.trim();
+    if (status) {
+      await exec(`git add "${pageName}.md"`, { cwd: tmpDir });
+      await exec(`git -c user.name="specs-bot" -c user.email="specs@example.com" commit -m "Update wiki for ${spec.specId}"`, {
+        cwd: tmpDir,
+      });
+      await exec(`git push`, { cwd: tmpDir });
+    }
+
+    return { url: wikiUrl };
   }
 }

--- a/packages/specs-cli/src/core/taskSelector.ts
+++ b/packages/specs-cli/src/core/taskSelector.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { SpecDoc } from './specParser';
 
 export interface NextTask {
@@ -7,7 +8,18 @@ export interface NextTask {
 
 export function selectNextTask(specs: SpecDoc[]): NextTask | null {
   if (!specs.length) return null;
-  for (const spec of specs) {
+  const sorted = [...specs].sort((a, b) => {
+    try {
+      const aTime = fs.statSync(a.filePath).mtimeMs;
+      const bTime = fs.statSync(b.filePath).mtimeMs;
+      return bTime - aTime;
+    } catch (err) {
+      // Fall back to original order if stat fails for either file.
+      return 0;
+    }
+  });
+
+  for (const spec of sorted) {
     const feature = spec.features.find((f) => !!f.id);
     if (feature) {
       return { spec, featureId: feature.id };

--- a/specs/codex-cli-specs-command.feature.md
+++ b/specs/codex-cli-specs-command.feature.md
@@ -1,0 +1,53 @@
+---
+spec_id: specs.codex-cli-command
+title: Expose specs CLI inside Codex CLI
+features:
+  - id: codex.subcommand
+    accept:
+      - "`codex specs` (or `codex-cli specs`) delegates to the specs CLI with parity for core verbs: scan, templates, next, sync, close, coverage"
+      - "Help output shows the specs verbs and forwards exit codes/stdout so guardrails work inside Codex sessions"
+  - id: install.lifecycle
+    accept:
+      - "Document install/upgrade/uninstall paths (npm global, npx fallback, optional Homebrew) and how Codex resolves the binary"
+      - "Provide a scripted install check that warns when specs is absent or outdated and offers a one-liner to fix"
+  - id: spec-kit.context
+    accept:
+      - "`codex specs templates` or `codex specs scan --refresh-spec-kit` refreshes spec-kit templates and drops them into Codex context files"
+      - "Spec-kit availability is validated in guard checks and surfaced in Codex CLI output before running specs verbs"
+  - id: guardrails.integration
+    accept:
+      - "Guard workflow still enforces open issue, ADR URL + approval marker, wiki URL, and no CHANGES_REQUESTED when invoked via Codex"
+      - "Example PR uses the spec-specific template and passes spec-kit refresh/check, coverage, conformance (if applicable), and security scans"
+  - id: example.enablement
+    accept:
+      - "Example app demonstrates `codex specs …` end-to-end (scan → next → sync → close) and records results in issue/PR checklists"
+      - "Docs link from the example app README shows how to toggle/disable the Codex specs command and how to uninstall specs"
+---
+
+## Summary
+Expose the specs CLI as a first-class Codex CLI command (`codex specs`) so users can run scan/next/sync/close from the same interface. Include clear install/upgrade/uninstall guidance, spec-kit template refresh, and guardrails that mirror existing CI checks. Provide an example app path that proves the flow works and is easy to remove if desired.
+
+## Meta prompt
+You are drafting a specification to expose the specs CLI inside Codex CLI. Include:
+- Commands: `codex specs` delegating to specs CLI verbs (scan, templates, next, sync, close, coverage) with help/exit-code parity.
+- Install/upgrade/uninstall guidance (npm global, npx fallback, optional Homebrew), detection of missing/outdated specs, and a one-liner fixer.
+- Spec-kit integration: refresh templates (`specs templates` or `specs scan --refresh-spec-kit`) and ensure Codex context files include refreshed templates.
+- Guardrails: enforce open issue, ADR discussion URL + approval marker, wiki link, no pending review comments, required checks (spec-kit refresh/check, coverage, conformance, security scans) even when invoked via Codex.
+- Example app: demonstrate the flow end-to-end with checklists updating in issues/PRs, and document how to disable/remove the Codex specs command.
+
+## Workflow
+- Entry: users run `codex specs <verb>`; Codex locates the specs binary (bundled, global npm, or npx fallback) and surfaces missing/outdated warnings with fix commands.
+- Templates: `codex specs templates` or `codex specs scan --refresh-spec-kit` refreshes spec-kit templates and places them into Codex context for plan/tasks generation.
+- Sync/guard: `codex specs sync` keeps project issues/board in Todo/In Progress/Done; guard checks still require ADR URL + approval, wiki link, and open issue; `codex specs close` enforces release + green checks + no pending review comments.
+- Docs: README/CLI help page explains install/uninstall, supported verbs, environment needs (GH auth), and how to disable the Codex hook.
+
+## Automation details
+- Codex CLI detects specs via PATH/global npm and falls back to `npx specs`; `codex specs --doctor` reports version and install status with suggested fixes.
+- GH Actions guard workflow remains in place; PRs must use the spec-specific template and stay green on spec-kit refresh/check, coverage, conformance (if applicable), and security scans (Semgrep/OSV-Scanner/Gitleaks/Checkov).
+- Spec-kit refresh is validated via `specs scan --refresh-spec-kit` and `npm run spec-kit:check`; failures block sync/close.
+- Example app CI runs the same guard + coverage/conformance/security checks when using `codex specs`.
+
+## Open questions/risks
+- Packaging choice for Codex bundling vs. external dependency; handling air-gapped installs.
+- Permission scope for GH tokens when invoked from Codex; fallback behavior if discussions/wiki permissions are missing.
+- Version skew between bundled specs and latest spec-kit templates; strategy for override/pinning.

--- a/specs/codex-cli-specs-command.plan.md
+++ b/specs/codex-cli-specs-command.plan.md
@@ -1,0 +1,48 @@
+# Implementation Plan: specs.codex-cli-command
+
+**Branch**: `specs-codex-cli-command-plan` | **Date**: 2025-12-12 | **Spec**: specs/codex-cli-specs-command.feature.md  
+**Input**: Refreshed spec-kit templates (`specs scan --refresh-spec-kit`) and current context (`.specs/current-task.md`, `.codex/context-spec-next.md`)
+
+## Summary
+Add a Codex CLI subcommand (`codex specs`) that delegates to the specs CLI (scan/templates/next/sync/close/coverage) with exit-code parity, install/upgrade/uninstall guidance, spec-kit refresh surfacing in Codex context, and guardrail parity (issue/ADR/wiki/approval/no pending reviews, required checks). Include an example app path that demonstrates end-to-end usage and how to disable/remove the hook.
+
+## Technical Context
+**Language/Version**: Node.js/TypeScript (Codex CLI + specs CLI)  
+**Primary Dependencies**: specs CLI, spec-kit templates, GitHub CLI (auth), GitHub Actions (guard, coverage, conformance, security, release)  
+**Storage**: Documentation under `specs/` + example app README; no DB changes  
+**Testing**: Guard workflow + CI (spec-kit check/refresh, coverage, conformance if applicable, security scans), manual `codex specs --doctor` sanity  
+**Target Platform**: Codex CLI users in this repo and downstream consumers  
+**Constraints**: ADR #42 approval required before implementation; PRs must use spec-specific template; required checks must be green; release-before-close rule applies
+
+## Project Structure
+Documentation for this spec lives in `specs/`:
+```
+specs/
+├── codex-cli-specs-command.feature.md   # spec
+├── codex-cli-specs-command.plan.md      # this plan
+└── codex-cli-specs-command.tasks.md     # tasks derived from plan
+```
+Context files and templates:
+```
+.specs/current-task.md
+.codex/context-spec-next.md
+.specs/spec-kit/*.md   # refreshed spec-kit templates (spec/plan/tasks)
+```
+
+## Implementation Strategy
+1) Command surface: add `codex specs` wrapper that discovers the specs binary (bundled/global/npx fallback) and forwards args/help/exit codes.  
+2) Install lifecycle: document install/upgrade/uninstall paths; add `codex specs --doctor` to report version and suggest one-line fixes.  
+3) Spec-kit context: ensure `codex specs templates` / `codex specs scan --refresh-spec-kit` refresh templates and drop them into Codex context files.  
+4) Guardrails parity: keep guard workflow enforcing issue/ADR/wiki/approval/no pending reviews and required checks when invoked via Codex; ensure PR uses spec-specific template.  
+5) Example enablement: update example app docs to show `codex specs` end-to-end, with toggle/disable instructions.  
+6) Governance & close: maintain ADR/wiki links, run `specs sync`, bump version + release before `specs close`, and ensure no pending review comments before merge.
+
+## Dependencies & Execution Order
+- Prereqs: ADR discussion #42 (approved); templates refreshed.  
+- Sequence: Plan/tasks → ADR/wikilink updates → command + doctor → docs + example enablement → guard validation → release + close.  
+- Testing: CI guard + coverage/conformance/security + spec-kit refresh/check on PRs and main.
+
+## Notes
+- Record spec-kit template source/commit in PR body when refreshed.  
+- Keep Codex command optional/disable-able; document how to remove global install if undesired.  
+- Ensure GH token scopes permit discussions/wiki/comments when running guard via Codex.

--- a/specs/codex-cli-specs-command.tasks.md
+++ b/specs/codex-cli-specs-command.tasks.md
@@ -1,0 +1,35 @@
+# Tasks: specs.codex-cli-command
+
+**Input**: spec (`specs/codex-cli-specs-command.feature.md`), plan (`specs/codex-cli-specs-command.plan.md`), refreshed spec-kit templates  
+**Prerequisites**: ADR #42 approved; templates refreshed; guard/CI active
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup & Guard (Shared)
+- [ ] T001 [P] [COD] Refresh spec-kit templates (`specs scan --refresh-spec-kit`) and note template source/commit in PR body.
+- [ ] T002 [P] [COD] Ensure PR body uses spec-specific template with issue #41, ADR #42, wiki link, and required checks checklist.
+- [ ] T003 [P] [COD] Verify guard workflow enforces issue/ADR/wiki/approval/no CHANGES_REQUESTED for Codex-triggered runs.
+
+## Phase 2: Command Surface
+- [ ] T010 [COD] Add `codex specs` subcommand that delegates to specs CLI verbs (scan/templates/next/sync/close/coverage) with help/exit-code parity.
+- [ ] T011 [COD] Implement binary resolution (bundled -> PATH/global npm -> `npx specs`) and bubble missing/outdated warnings.
+- [ ] T012 [COD] Add `codex specs --doctor` to report detected specs version, install path, and a one-line fix if missing/outdated.
+
+## Phase 3: Spec-kit Context & Guardrails
+- [ ] T020 [COD] Wire `codex specs templates` / `codex specs scan --refresh-spec-kit` to drop refreshed templates into Codex context files.
+- [ ] T021 [COD] Surface spec-kit availability/refresh status in Codex output; fail early if unavailable.
+- [ ] T022 [COD] Keep guard workflow parity for Codex invocation (issue open, ADR URL + approval marker, wiki URL, no pending review comments, required checks list).
+
+## Phase 4: Docs & Example
+- [ ] T030 [P] [COD] Document install/upgrade/uninstall paths (npm global, npx fallback, optional Homebrew) and how Codex resolves the binary.
+- [ ] T031 [P] [COD] Update example app README to demonstrate `codex specs` flow (scan → next → sync → close) and how to disable/remove the hook.
+- [ ] T032 [P] [COD] Add note on toggling Codex specs command and uninstalling specs for consumers who opt out.
+
+## Phase 5: Release & Close Preconditions
+- [ ] T040 [COD] Bump minor version + changelog entry once feature is ready; include issue/ADR/wiki links.
+- [ ] T041 [COD] Dispatch release workflow (workflow_dispatch) with new version; verify ADR/wiki/issue comments posted.
+- [ ] T042 [COD] Run `specs close specs.codex-cli-command --issue 41 --pr <#>` only after release and all checks green; ensure no pending review comments.
+
+## Dependencies & Execution Order
+- Phase 1 sets guardrails; Phase 2/3 build the command + guard parity; Phase 4 documents/example; Phase 5 release/close.  
+- Tasks marked [P] can run in parallel; others depend on command/guard readiness.


### PR DESCRIPTION
## Summary
- Add codex CLI wrapper (.codex/commands/specs) with doctor fallback and update README install/usage guidance.
- Auto-create/link ADR discussion and wiki page during specs sync; guard checks now accept links from issue or PR body and require ADR approval.
- Add plan/tasks/spec docs for specs.codex-cli-command and improve task selection recency heuristic.

Spec issue: #41
ADR/design review discussion: https://github.com/ganesh47/specs/discussions/42
Wiki page for spec/ADR: https://github.com/ganesh47/specs/wiki/Spec-Expose-specs-CLI-inside-Codex-CLI

## Required checks
- [ ] spec-kit templates refreshed (Fetched spec-kit template: templates/spec-template.md -> .specs/spec-kit/spec-template.md
Fetched spec-kit template: templates/plan-template.md -> .specs/spec-kit/plan-template.md
Fetched spec-kit template: templates/tasks-template.md -> .specs/spec-kit/tasks-template.md
Fetched spec-kit template: spec-driven.md -> .specs/spec-kit/spec-driven.md
spec-kit templates refreshed from github/spec-kit@main
Found 8 spec file(s).
- specs.phase-mapping (5 feature(s))
- specs.spec-kit-integration (6 feature(s))
- release.workflow (5 feature(s))
- specs.example-project (3 feature(s))
- devsecops.workflow-isolation (5 feature(s))
- workflow.commit-pr (3 feature(s))
- specs.codex-cli-command (5 feature(s))
- specs.baseline (4 feature(s)) or Fetched spec-kit template: templates/spec-template.md -> .specs/spec-kit/spec-template.md
Fetched spec-kit template: templates/plan-template.md -> .specs/spec-kit/plan-template.md
Fetched spec-kit template: templates/tasks-template.md -> .specs/spec-kit/tasks-template.md
Fetched spec-kit template: spec-driven.md -> .specs/spec-kit/spec-driven.md
Downloaded spec-kit templates from github/spec-kit@main to .specs/spec-kit)
- [ ] Spec-kit availability check passed (
> specs-monorepo@0.3.0 spec-kit:check
> node scripts/check-spec-kit.js

ok: spec-driven.md
ok: templates/spec-template.md
ok: templates/plan-template.md
ok: templates/tasks-template.md
spec-kit template availability check passed)
- [ ] Specs coverage run
- [ ] Example conformance run (if applicable)
- [ ] Security scans (Semgrep/OSV-Scanner/Gitleaks/Checkov) green
- [ ] ADR/design review approved before merge
- [ ] Issue and project status updated (Todo  In Progress  Done)
