### PR TITLE
Refs #41: Harden wiki sync and spec-kit doctor

### DIFF
--- a/.codex/commands/specs
+++ b/.codex/commands/specs
@@ -31,6 +31,18 @@ doctor() {
     echo "- specs not installed globally; will fallback to npx."
     echo "  Install with: npm i -g specs"
   fi
+  if [[ -f "$ROOT_DIR/package.json" ]]; then
+    if npm run -s spec-kit:check --if-present >/dev/null 2>&1; then
+      echo "- spec-kit: check passed (npm run spec-kit:check)"
+    else
+      echo "- spec-kit: check failed or unavailable; run 'npm run spec-kit:check' after installing deps"
+    fi
+  fi
+  if [[ -d "$ROOT_DIR/.specs/spec-kit" ]]; then
+    echo "- spec-kit templates present at .specs/spec-kit (refresh with codex specs scan --refresh-spec-kit)"
+  else
+    echo "- spec-kit templates missing; refresh with codex specs scan --refresh-spec-kit"
+  fi
   echo "- To refresh spec-kit templates: codex specs scan --refresh-spec-kit"
   echo "- To uninstall: npm rm -g specs; remove .codex/commands/specs to disable the hook"
 }

--- a/packages/specs-cli/src/core/ghClient.ts
+++ b/packages/specs-cli/src/core/ghClient.ts
@@ -544,11 +544,17 @@ export class GhClient {
 
     const status = (await exec(`git status --porcelain`, { cwd: tmpDir })).stdout.trim();
     if (status) {
-      await exec(`git add "${pageName}.md"`, { cwd: tmpDir });
-      await exec(`git -c user.name="specs-bot" -c user.email="specs@example.com" commit -m "Update wiki for ${spec.specId}"`, {
-        cwd: tmpDir,
-      });
-      await exec(`git push`, { cwd: tmpDir });
+      try {
+        await exec(`git add "${pageName}.md"`, { cwd: tmpDir });
+        await exec(
+          `git -c user.name="specs-bot" -c user.email="specs@example.com" commit -m "Update wiki for ${spec.specId}"`,
+          { cwd: tmpDir }
+        );
+        await exec(`git push`, { cwd: tmpDir });
+      } catch (error: any) {
+        // eslint-disable-next-line no-console
+        console.warn(`Warning: failed to push wiki update for ${spec.specId}: ${error?.stderr || error?.message || error}`);
+      }
     }
 
     return { url: wikiUrl };


### PR DESCRIPTION
## Summary
- Skip wiki commit/push failures from blocking sync; warn and continue so ADR/wiki links still land in issues.
- codex specs doctor now reports spec-kit check status and template presence alongside binary resolution.

Spec issue: #41
ADR/design review discussion: https://github.com/ganesh47/specs/discussions/42
Wiki page for spec/ADR: https://github.com/ganesh47/specs/wiki/Spec-Expose-specs-CLI-inside-Codex-CLI

## Required checks
- [ ] spec-kit templates refreshed (Fetched spec-kit template: templates/spec-template.md -> .specs/spec-kit/spec-template.md
Fetched spec-kit template: templates/plan-template.md -> .specs/spec-kit/plan-template.md
Fetched spec-kit template: templates/tasks-template.md -> .specs/spec-kit/tasks-template.md
Fetched spec-kit template: spec-driven.md -> .specs/spec-kit/spec-driven.md
spec-kit templates refreshed from github/spec-kit@main
Found 8 spec file(s).
- specs.phase-mapping (5 feature(s))
- specs.spec-kit-integration (6 feature(s))
- release.workflow (5 feature(s))
- specs.example-project (3 feature(s))
- devsecops.workflow-isolation (5 feature(s))
- workflow.commit-pr (3 feature(s))
- specs.codex-cli-command (5 feature(s))
- specs.baseline (4 feature(s)) or Fetched spec-kit template: templates/spec-template.md -> .specs/spec-kit/spec-template.md
Fetched spec-kit template: templates/plan-template.md -> .specs/spec-kit/plan-template.md
Fetched spec-kit template: templates/tasks-template.md -> .specs/spec-kit/tasks-template.md
Fetched spec-kit template: spec-driven.md -> .specs/spec-kit/spec-driven.md
Downloaded spec-kit templates from github/spec-kit@main to .specs/spec-kit)
- [ ] Spec-kit availability check passed (
> specs-monorepo@0.3.0 spec-kit:check
> node scripts/check-spec-kit.js

ok: spec-driven.md
ok: templates/spec-template.md
ok: templates/plan-template.md
ok: templates/tasks-template.md
spec-kit template availability check passed)
- [ ] Specs coverage run
- [ ] Example conformance run (if applicable)
- [ ] Security scans (Semgrep/OSV-Scanner/Gitleaks/Checkov) green
- [ ] ADR/design review approved before merge
- [ ] Issue and project status updated (Todo → In Progress → Done)
