### PR TITLE
Refs #41: Skip wiki push when token missing

### DIFF
--- a/packages/specs-cli/src/core/ghClient.ts
+++ b/packages/specs-cli/src/core/ghClient.ts
@@ -544,6 +544,13 @@ export class GhClient {
 
     const status = (await exec(`git status --porcelain`, { cwd: tmpDir })).stdout.trim();
     if (status) {
+      if (!token) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Warning: wiki changes detected for ${spec.specId} but no GH_TOKEN available; skipping push.`
+        );
+        return { url: wikiUrl };
+      }
       try {
         await exec(`git add "${pageName}.md"`, { cwd: tmpDir });
         await exec(


### PR DESCRIPTION
## Summary
- Skip wiki commit/push when GH_TOKEN is unavailable; continue syncing ADR/wiki links without failing.

Spec issue: #41
ADR/design review discussion: https://github.com/ganesh47/specs/discussions/42
Wiki page for spec/ADR: https://github.com/ganesh47/specs/wiki/Spec-Expose-specs-CLI-inside-Codex-CLI

## Required checks
- [ ] spec-kit templates refreshed (Fetched spec-kit template: templates/spec-template.md -> .specs/spec-kit/spec-template.md
Fetched spec-kit template: templates/plan-template.md -> .specs/spec-kit/plan-template.md
Fetched spec-kit template: templates/tasks-template.md -> .specs/spec-kit/tasks-template.md
Fetched spec-kit template: spec-driven.md -> .specs/spec-kit/spec-driven.md
spec-kit templates refreshed from github/spec-kit@main
Found 8 spec file(s).
- specs.phase-mapping (5 feature(s))
- specs.spec-kit-integration (6 feature(s))
- release.workflow (5 feature(s))
- specs.example-project (3 feature(s))
- devsecops.workflow-isolation (5 feature(s))
- workflow.commit-pr (3 feature(s))
- specs.codex-cli-command (5 feature(s))
- specs.baseline (4 feature(s)) or Fetched spec-kit template: templates/spec-template.md -> .specs/spec-kit/spec-template.md
Fetched spec-kit template: templates/plan-template.md -> .specs/spec-kit/plan-template.md
Fetched spec-kit template: templates/tasks-template.md -> .specs/spec-kit/tasks-template.md
Fetched spec-kit template: spec-driven.md -> .specs/spec-kit/spec-driven.md
Downloaded spec-kit templates from github/spec-kit@main to .specs/spec-kit)
- [ ] Spec-kit availability check passed (
> specs-monorepo@0.3.0 spec-kit:check
> node scripts/check-spec-kit.js

ok: spec-driven.md
ok: templates/spec-template.md
ok: templates/plan-template.md
ok: templates/tasks-template.md
spec-kit template availability check passed)
- [ ] Specs coverage run
- [ ] Example conformance run (if applicable)
- [ ] Security scans (Semgrep/OSV-Scanner/Gitleaks/Checkov) green
- [ ] ADR/design review approved before merge
- [ ] Issue and project status updated (Todo → In Progress → Done)
